### PR TITLE
Unify memes and GIFs tabs with user and community content

### DIFF
--- a/src/components/chat/MemeStickerPicker.tsx
+++ b/src/components/chat/MemeStickerPicker.tsx
@@ -298,9 +298,9 @@ export const MemeStickerPicker: React.FC<MemeStickerPickerProps> = ({
           isMobile ? "h-24 px-2" : "h-48"
         )}>
           <Sparkles className={cn("mb-2 opacity-50", isMobile ? "w-6 h-6" : "w-12 h-12")} />
-          <p className={cn("font-medium", isMobile ? "text-xs" : "text-lg")}>No stickers found</p>
+          <p className={cn("font-medium", isMobile ? "text-xs" : "text-lg")}>No {activeTab} found</p>
           <p className={cn(isMobile ? "text-[10px] mt-0.5" : "text-sm")}>
-            {searchQuery ? "Try a different search" : "No stickers available"}
+            {searchQuery ? "Try a different search" : `Create your own ${activeTab} using the Create tab!`}
           </p>
         </div>
       );

--- a/src/components/chat/MemeStickerPicker.tsx
+++ b/src/components/chat/MemeStickerPicker.tsx
@@ -664,16 +664,28 @@ const StickerCard: React.FC<StickerCardProps> = ({
         onTouchEnd={isMobile ? handleTouchEnd : undefined}
         onMouseLeave={handleMouseLeave}
       >
-        {sticker.type === "image" || sticker.type === "gif" ? (
+        {sticker.type === "image" || sticker.type === "gif" || sticker.type === "meme" ? (
           <div className="relative w-full h-full">
             <img
               src={sticker.thumbnailUrl || sticker.fileUrl}
               alt={sticker.name}
               className="w-full h-full object-cover rounded-md"
+              loading="lazy"
             />
-            {sticker.animated && (
+            {(sticker.animated || sticker.type === "gif") && (
               <div className="absolute top-1 right-1 bg-black/70 text-white text-xs px-1 py-0.5 rounded">
                 GIF
+              </div>
+            )}
+            {sticker.type === "meme" && !sticker.animated && (
+              <div className="absolute bottom-1 left-1 bg-purple-600/80 text-white text-xs px-1 py-0.5 rounded">
+                MEME
+              </div>
+            )}
+            {/* Show if this is user-created content */}
+            {sticker.tags?.includes("user-generated") && (
+              <div className="absolute top-1 left-1 bg-blue-600/80 text-white text-xs px-1 py-0.5 rounded">
+                YOURS
               </div>
             )}
           </div>

--- a/src/components/chat/MemeStickerPicker.tsx
+++ b/src/components/chat/MemeStickerPicker.tsx
@@ -62,6 +62,7 @@ import {
   UserStickerLibrary,
   EMOJI_STICKER_PACKS
 } from "@/types/sticker";
+import { SAMPLE_MEMES, SAMPLE_GIFS, COMMUNITY_MEME_GIF_PACKS } from "@/data/sampleMemesGifsData";
 import { EnhancedMediaCreationPanel } from "./EnhancedMediaCreationPanel";
 import { useUserCollections } from "@/contexts/UserCollectionsContext";
 
@@ -93,51 +94,54 @@ export const MemeStickerPicker: React.FC<MemeStickerPickerProps> = ({
   const [showCreateDialog, setShowCreateDialog] = useState(false);
   const [selectedPack, setSelectedPack] = useState<StickerPackData | null>(null);
   
-  // Create dynamic packs from user collections
-  const userCollectionPacks: StickerPackData[] = [
-    {
-      id: "memes",
-      name: "My Memes",
-      description: `Your custom memes (${collections.memes.length})`,
-      category: "memes" as StickerCategory,
-      stickers: collections.memes,
-      creatorId: "user",
-      creatorName: "You",
-      downloadCount: 0,
-      rating: 5.0,
-      ratingCount: 0,
-      isPublic: false,
-      isPremium: false,
-      isOfficial: false,
-      isCustom: true,
-      tags: ["memes", "custom"],
-      createdAt: new Date().toISOString(),
-      updatedAt: new Date().toISOString(),
-      thumbnailUrl: collections.memes[0]?.thumbnailUrl || "",
-      price: 0,
-    },
-    {
-      id: "gifs",
-      name: "My GIFs",
-      description: `Your animated GIFs (${collections.gifs.length})`,
-      category: "gifs" as StickerCategory,
-      stickers: collections.gifs,
-      creatorId: "user",
-      creatorName: "You",
-      downloadCount: 0,
-      rating: 5.0,
-      ratingCount: 0,
-      isPublic: false,
-      isPremium: false,
-      isOfficial: false,
-      isCustom: true,
-      tags: ["gifs", "animated", "custom"],
-      createdAt: new Date().toISOString(),
-      updatedAt: new Date().toISOString(),
-      thumbnailUrl: collections.gifs[0]?.thumbnailUrl || "",
-      price: 0,
-    }
-  ];
+  // Create unified packs that combine user collections with community content
+  const unifiedMemePack: StickerPackData = {
+    id: "memes",
+    name: "Memes",
+    description: `All memes (${collections.memes.length + SAMPLE_MEMES.length})`,
+    category: "memes" as StickerCategory,
+    // User memes first, then community memes
+    stickers: [...collections.memes, ...SAMPLE_MEMES],
+    creatorId: "unified",
+    creatorName: "Community",
+    downloadCount: 0,
+    rating: 5.0,
+    ratingCount: 0,
+    isPublic: true,
+    isPremium: false,
+    isOfficial: false,
+    isCustom: false,
+    tags: ["memes", "community", "unified"],
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    thumbnailUrl: collections.memes[0]?.thumbnailUrl || SAMPLE_MEMES[0]?.thumbnailUrl || "",
+    price: 0,
+  };
+
+  const unifiedGifPack: StickerPackData = {
+    id: "gifs",
+    name: "GIFs",
+    description: `All GIFs (${collections.gifs.length + SAMPLE_GIFS.length})`,
+    category: "gifs" as StickerCategory,
+    // User GIFs first, then community GIFs
+    stickers: [...collections.gifs, ...SAMPLE_GIFS],
+    creatorId: "unified",
+    creatorName: "Community",
+    downloadCount: 0,
+    rating: 5.0,
+    ratingCount: 0,
+    isPublic: true,
+    isPremium: false,
+    isOfficial: false,
+    isCustom: false,
+    tags: ["gifs", "animated", "community", "unified"],
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    thumbnailUrl: collections.gifs[0]?.thumbnailUrl || SAMPLE_GIFS[0]?.thumbnailUrl || "",
+    price: 0,
+  };
+
+  const userCollectionPacks: StickerPackData[] = [unifiedMemePack, unifiedGifPack];
 
   const [userLibrary, setUserLibrary] = useState<UserStickerLibrary>({
     recentStickers: [],
@@ -149,52 +153,55 @@ export const MemeStickerPicker: React.FC<MemeStickerPickerProps> = ({
   const [availablePacks, setAvailablePacks] = useState<StickerPackData[]>(userCollectionPacks);
   const [trendingPacks, setTrendingPacks] = useState<StickerPackData[]>([]);
 
-  // Update packs when collections change
+  // Update packs when collections change to maintain unified view
   React.useEffect(() => {
-    const updatedPacks = [
-      {
-        id: "memes",
-        name: "My Memes",
-        description: `Your custom memes (${collections.memes.length})`,
-        category: "memes" as StickerCategory,
-        stickers: collections.memes,
-        creatorId: "user",
-        creatorName: "You",
-        downloadCount: 0,
-        rating: 5.0,
-        ratingCount: 0,
-        isPublic: false,
-        isPremium: false,
-        isOfficial: false,
-        isCustom: true,
-        tags: ["memes", "custom"],
-        createdAt: new Date().toISOString(),
-        updatedAt: new Date().toISOString(),
-        thumbnailUrl: collections.memes[0]?.thumbnailUrl || "",
-        price: 0,
-      },
-      {
-        id: "gifs",
-        name: "My GIFs",
-        description: `Your animated GIFs (${collections.gifs.length})`,
-        category: "gifs" as StickerCategory,
-        stickers: collections.gifs,
-        creatorId: "user",
-        creatorName: "You",
-        downloadCount: 0,
-        rating: 5.0,
-        ratingCount: 0,
-        isPublic: false,
-        isPremium: false,
-        isOfficial: false,
-        isCustom: true,
-        tags: ["gifs", "animated", "custom"],
-        createdAt: new Date().toISOString(),
-        updatedAt: new Date().toISOString(),
-        thumbnailUrl: collections.gifs[0]?.thumbnailUrl || "",
-        price: 0,
-      }
-    ];
+    const updatedUnifiedMemePack: StickerPackData = {
+      id: "memes",
+      name: "Memes",
+      description: `All memes (${collections.memes.length + SAMPLE_MEMES.length})`,
+      category: "memes" as StickerCategory,
+      // User memes first, then community memes
+      stickers: [...collections.memes, ...SAMPLE_MEMES],
+      creatorId: "unified",
+      creatorName: "Community",
+      downloadCount: 0,
+      rating: 5.0,
+      ratingCount: 0,
+      isPublic: true,
+      isPremium: false,
+      isOfficial: false,
+      isCustom: false,
+      tags: ["memes", "community", "unified"],
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+      thumbnailUrl: collections.memes[0]?.thumbnailUrl || SAMPLE_MEMES[0]?.thumbnailUrl || "",
+      price: 0,
+    };
+
+    const updatedUnifiedGifPack: StickerPackData = {
+      id: "gifs",
+      name: "GIFs",
+      description: `All GIFs (${collections.gifs.length + SAMPLE_GIFS.length})`,
+      category: "gifs" as StickerCategory,
+      // User GIFs first, then community GIFs
+      stickers: [...collections.gifs, ...SAMPLE_GIFS],
+      creatorId: "unified",
+      creatorName: "Community",
+      downloadCount: 0,
+      rating: 5.0,
+      ratingCount: 0,
+      isPublic: true,
+      isPremium: false,
+      isOfficial: false,
+      isCustom: false,
+      tags: ["gifs", "animated", "community", "unified"],
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+      thumbnailUrl: collections.gifs[0]?.thumbnailUrl || SAMPLE_GIFS[0]?.thumbnailUrl || "",
+      price: 0,
+    };
+
+    const updatedPacks = [updatedUnifiedMemePack, updatedUnifiedGifPack];
 
     setAvailablePacks(updatedPacks);
     setUserLibrary(prev => ({

--- a/src/components/chat/MemeStickerPicker.tsx
+++ b/src/components/chat/MemeStickerPicker.tsx
@@ -473,7 +473,7 @@ export const MemeStickerPicker: React.FC<MemeStickerPickerProps> = ({
                   onMediaSaved={(mediaId, collection) => {
                     toast({
                       title: "Media saved!",
-                      description: `Your ${collection.slice(0, -1)} has been saved to your collection`,
+                      description: `Your ${collection.slice(0, -1)} has been saved to your collection and is now available in the ${collection.charAt(0).toUpperCase() + collection.slice(1)} tab`,
                     });
                     // Switch to the appropriate tab to show the saved media
                     if (collection === "memes") {

--- a/src/contexts/FeedContext.tsx
+++ b/src/contexts/FeedContext.tsx
@@ -2,18 +2,20 @@ import React, { createContext, useContext, useState, ReactNode } from 'react';
 
 interface UnifiedFeedItem {
   id: string;
-  type: 
-    | "post" 
-    | "product" 
-    | "job" 
-    | "freelancer_skill" 
-    | "sponsored_post" 
-    | "ad" 
-    | "live_event" 
+  type:
+    | "post"
+    | "product"
+    | "job"
+    | "freelancer_skill"
+    | "sponsored_post"
+    | "ad"
+    | "live_event"
     | "community_event"
     | "story_recap"
     | "recommended_user"
-    | "trending_topic";
+    | "trending_topic"
+    | "meme"
+    | "gif";
   timestamp: Date;
   priority: number;
   author?: {

--- a/src/data/sampleMemesGifsData.ts
+++ b/src/data/sampleMemesGifsData.ts
@@ -1,0 +1,253 @@
+import { StickerData, StickerPackData } from "@/types/sticker";
+
+// Sample meme images with placeholder data - in a real app these would be actual image URLs
+export const SAMPLE_MEMES: StickerData[] = [
+  {
+    id: "meme_1",
+    name: "Drake Pointing",
+    fileUrl: "https://via.placeholder.com/300x300/FFB6C1/000000?text=Drake+Pointing",
+    thumbnailUrl: "https://via.placeholder.com/150x150/FFB6C1/000000?text=Drake",
+    packId: "community_memes",
+    packName: "Community Memes",
+    type: "meme",
+    width: 300,
+    height: 300,
+    usageCount: 1250,
+    tags: ["drake", "pointing", "popular", "choice"],
+    metadata: {
+      topText: "",
+      bottomText: "",
+      stickerType: "meme"
+    }
+  },
+  {
+    id: "meme_2", 
+    name: "Distracted Boyfriend",
+    fileUrl: "https://via.placeholder.com/400x300/98FB98/000000?text=Distracted+Boyfriend",
+    thumbnailUrl: "https://via.placeholder.com/150x150/98FB98/000000?text=Distracted",
+    packId: "community_memes",
+    packName: "Community Memes", 
+    type: "meme",
+    width: 400,
+    height: 300,
+    usageCount: 980,
+    tags: ["distracted", "boyfriend", "choice", "meme"],
+    metadata: {
+      topText: "",
+      bottomText: "",
+      stickerType: "meme"
+    }
+  },
+  {
+    id: "meme_3",
+    name: "Woman Yelling at Cat",
+    fileUrl: "https://via.placeholder.com/500x300/DDA0DD/000000?text=Woman+Yelling+Cat",
+    thumbnailUrl: "https://via.placeholder.com/150x150/DDA0DD/000000?text=Yelling+Cat",
+    packId: "community_memes",
+    packName: "Community Memes",
+    type: "meme", 
+    width: 500,
+    height: 300,
+    usageCount: 875,
+    tags: ["woman", "cat", "yelling", "table", "argument"],
+    metadata: {
+      topText: "",
+      bottomText: "",
+      stickerType: "meme"
+    }
+  },
+  {
+    id: "meme_4",
+    name: "This is Fine",
+    fileUrl: "https://via.placeholder.com/400x400/F0E68C/000000?text=This+is+Fine",
+    thumbnailUrl: "https://via.placeholder.com/150x150/F0E68C/000000?text=Fine",
+    packId: "community_memes",
+    packName: "Community Memes",
+    type: "meme",
+    width: 400,
+    height: 400,
+    usageCount: 756,
+    tags: ["fine", "fire", "dog", "calm", "disaster"],
+    metadata: {
+      topText: "",
+      bottomText: "",
+      stickerType: "meme"
+    }
+  },
+  {
+    id: "meme_5",
+    name: "Expanding Brain",
+    fileUrl: "https://via.placeholder.com/300x600/ADD8E6/000000?text=Expanding+Brain",
+    thumbnailUrl: "https://via.placeholder.com/150x150/ADD8E6/000000?text=Brain",
+    packId: "community_memes",
+    packName: "Community Memes",
+    type: "meme",
+    width: 300,
+    height: 600,
+    usageCount: 643,
+    tags: ["brain", "expanding", "smart", "levels", "evolution"],
+    metadata: {
+      topText: "",
+      bottomText: "",
+      stickerType: "meme"
+    }
+  }
+];
+
+// Sample GIF data - in a real app these would be actual GIF URLs
+export const SAMPLE_GIFS: StickerData[] = [
+  {
+    id: "gif_1",
+    name: "Dancing Cat",
+    fileUrl: "https://via.placeholder.com/300x300/FFE4E1/000000?text=Dancing+Cat+GIF",
+    thumbnailUrl: "https://via.placeholder.com/150x150/FFE4E1/000000?text=Cat",
+    packId: "community_gifs",
+    packName: "Community GIFs",
+    type: "gif",
+    width: 300,
+    height: 300,
+    usageCount: 2150,
+    tags: ["cat", "dancing", "happy", "animated", "cute"],
+    animated: true,
+    metadata: {
+      duration: 2.5,
+      stickerType: "gif"
+    }
+  },
+  {
+    id: "gif_2",
+    name: "Thumbs Up",
+    fileUrl: "https://via.placeholder.com/250x250/E6E6FA/000000?text=Thumbs+Up+GIF",
+    thumbnailUrl: "https://via.placeholder.com/150x150/E6E6FA/000000?text=Thumbs",
+    packId: "community_gifs",
+    packName: "Community GIFs",
+    type: "gif",
+    width: 250,
+    height: 250,
+    usageCount: 1890,
+    tags: ["thumbs", "up", "approval", "good", "animated"],
+    animated: true,
+    metadata: {
+      duration: 1.8,
+      stickerType: "gif"
+    }
+  },
+  {
+    id: "gif_3",
+    name: "Applause",
+    fileUrl: "https://via.placeholder.com/350x250/F5DEB3/000000?text=Applause+GIF", 
+    thumbnailUrl: "https://via.placeholder.com/150x150/F5DEB3/000000?text=Clap",
+    packId: "community_gifs",
+    packName: "Community GIFs",
+    type: "gif",
+    width: 350,
+    height: 250,
+    usageCount: 1456,
+    tags: ["applause", "clapping", "celebration", "hands", "animated"],
+    animated: true,
+    metadata: {
+      duration: 3.0,
+      stickerType: "gif"
+    }
+  },
+  {
+    id: "gif_4",
+    name: "Heart Eyes",
+    fileUrl: "https://via.placeholder.com/280x280/FFB6C1/000000?text=Heart+Eyes+GIF",
+    thumbnailUrl: "https://via.placeholder.com/150x150/FFB6C1/000000?text=Hearts",
+    packId: "community_gifs", 
+    packName: "Community GIFs",
+    type: "gif",
+    width: 280,
+    height: 280,
+    usageCount: 1234,
+    tags: ["heart", "eyes", "love", "emoji", "animated"],
+    animated: true,
+    metadata: {
+      duration: 2.2,
+      stickerType: "gif"
+    }
+  },
+  {
+    id: "gif_5",
+    name: "Laughing Emoji",
+    fileUrl: "https://via.placeholder.com/300x300/98FB98/000000?text=Laughing+GIF",
+    thumbnailUrl: "https://via.placeholder.com/150x150/98FB98/000000?text=LOL",
+    packId: "community_gifs",
+    packName: "Community GIFs", 
+    type: "gif",
+    width: 300,
+    height: 300,
+    usageCount: 1876,
+    tags: ["laughing", "lol", "funny", "emoji", "animated"],
+    animated: true,
+    metadata: {
+      duration: 1.5,
+      stickerType: "gif"
+    }
+  },
+  {
+    id: "gif_6",
+    name: "Waving Hand",
+    fileUrl: "https://via.placeholder.com/250x250/DDA0DD/000000?text=Wave+GIF",
+    thumbnailUrl: "https://via.placeholder.com/150x150/DDA0DD/000000?text=Wave",
+    packId: "community_gifs",
+    packName: "Community GIFs",
+    type: "gif", 
+    width: 250,
+    height: 250,
+    usageCount: 1098,
+    tags: ["wave", "hand", "hello", "goodbye", "animated"],
+    animated: true,
+    metadata: {
+      duration: 2.0,
+      stickerType: "gif"
+    }
+  }
+];
+
+// Community packs that include both memes and GIFs
+export const COMMUNITY_MEME_GIF_PACKS: StickerPackData[] = [
+  {
+    id: "community_memes",
+    name: "Community Memes",
+    description: "Popular memes shared by the community",
+    creatorId: "system",
+    creatorName: "Softchat Community",
+    isPublic: true,
+    isPremium: false,
+    isOfficial: true,
+    downloadCount: 15750,
+    rating: 4.8,
+    ratingCount: 2340,
+    tags: ["memes", "community", "popular", "funny"],
+    category: "memes",
+    stickers: SAMPLE_MEMES,
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    thumbnailUrl: SAMPLE_MEMES[0]?.thumbnailUrl || "",
+    price: 0,
+    isCustom: false
+  },
+  {
+    id: "community_gifs", 
+    name: "Community GIFs",
+    description: "Animated GIFs shared by the community",
+    creatorId: "system",
+    creatorName: "Softchat Community",
+    isPublic: true,
+    isPremium: false,
+    isOfficial: true,
+    downloadCount: 12890,
+    rating: 4.7,
+    ratingCount: 1980,
+    tags: ["gifs", "animated", "community", "reactions"],
+    category: "gifs",
+    stickers: SAMPLE_GIFS,
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    thumbnailUrl: SAMPLE_GIFS[0]?.thumbnailUrl || "",
+    price: 0,
+    isCustom: false
+  }
+];


### PR DESCRIPTION
## Purpose

Users requested that the Memes and GIFs tabs in the chat page display all available content in a unified view, combining both user-created content and community content in the same tabs. Previously, user-created memes and GIFs were separated from community content, making it difficult to browse all available options in one place.

## Code changes

- **Modified MemeStickerPicker.tsx**: Replaced separate "My Memes" and "My GIFs" packs with unified packs that combine user collections with community content
- **Added sample data file**: Created `sampleMemesGifsData.ts` with placeholder community memes and GIFs to populate the unified tabs
- **Updated pack structure**: User content now appears first, followed by community content in the same tab
- **Enhanced empty state messaging**: Updated placeholder text to encourage content creation when tabs are empty
- **Improved save notifications**: Toast messages now indicate that saved content will appear in the respective tabs
- **Extended FeedContext types**: Added "meme" and "gif" types to support potential future feed integration

The unified approach ensures users can browse all available memes and GIFs (both their own creations and community content) in a single, cohesive interface.

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 143`

🔗 [Edit in Builder.io](https://builder.io/app/projects/c536d364a194463db56b1e231c18f286/curry-haven)

👀 [Preview Link](https://c536d364a194463db56b1e231c18f286-curry-haven.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>c536d364a194463db56b1e231c18f286</projectId>-->
<!--<branchName>curry-haven</branchName>-->