### PR TITLE
Fix mobile responsiveness and card styling issues

### DIFF
--- a/src/components/crypto/CryptoWalletBalanceCard.tsx
+++ b/src/components/crypto/CryptoWalletBalanceCard.tsx
@@ -71,10 +71,10 @@ export default function CryptoWalletBalanceCard({
               <Sparkles className="h-5 w-5 sm:h-6 sm:w-6 text-gray-900" />
             </div>
             <div>
-              <h2 className="text-lg sm:text-xl font-bold text-white drop-shadow-lg">
+              <h2 className="text-lg sm:text-xl font-bold text-gray-900 drop-shadow-lg">
                 Crypto Wallet
               </h2>
-              <p className="text-gray-200 text-xs sm:text-sm font-medium drop-shadow">
+              <p className="text-gray-800 text-xs sm:text-sm font-medium drop-shadow">
                 Digital asset portfolio
               </p>
             </div>

--- a/src/components/crypto/CryptoWalletBalanceCard.tsx
+++ b/src/components/crypto/CryptoWalletBalanceCard.tsx
@@ -106,10 +106,10 @@ export default function CryptoWalletBalanceCard({
           {/* Left: Balance */}
           <div className="space-y-2 flex-1">
             <div>
-              <p className="text-gray-200 text-2xs sm:text-xs font-medium uppercase tracking-wide mb-1">
+              <p className="text-gray-700 text-2xs sm:text-xs font-medium uppercase tracking-wide mb-1">
                 Total Portfolio Value
               </p>
-              <div className="text-2xl sm:text-3xl lg:text-4xl xl:text-5xl font-bold text-white drop-shadow-lg">
+              <div className="text-2xl sm:text-3xl lg:text-4xl xl:text-5xl font-bold text-gray-900 drop-shadow-lg">
                 {showBalance ? formatCurrency(totalBalance) : "••••••••"}
               </div>
             </div>

--- a/src/components/crypto/CryptoWalletBalanceCard.tsx
+++ b/src/components/crypto/CryptoWalletBalanceCard.tsx
@@ -141,13 +141,13 @@ export default function CryptoWalletBalanceCard({
           {/* Right: Primary Asset & Actions */}
           <div className="text-left sm:text-right space-y-2 sm:space-y-3 w-full sm:w-auto">
             <div>
-              <p className="text-gray-200 text-2xs sm:text-xs font-medium uppercase tracking-wide mb-1">
+              <p className="text-gray-700 text-2xs sm:text-xs font-medium uppercase tracking-wide mb-1">
                 Primary Asset
               </p>
-              <div className="text-lg sm:text-xl lg:text-2xl font-bold text-white drop-shadow">
+              <div className="text-lg sm:text-xl lg:text-2xl font-bold text-gray-900 drop-shadow">
                 {showBalance ? `${primaryAsset.balance} ${primaryAsset.symbol}` : "••••••"}
               </div>
-              <p className="text-gray-200 text-xs sm:text-sm font-medium">
+              <p className="text-gray-800 text-xs sm:text-sm font-medium">
                 ≈ {showBalance ? formatCurrency(primaryAsset.value) : "••••••"}
               </p>
             </div>

--- a/src/components/crypto/CryptoWalletBalanceCard.tsx
+++ b/src/components/crypto/CryptoWalletBalanceCard.tsx
@@ -139,30 +139,30 @@ export default function CryptoWalletBalanceCard({
           </div>
 
           {/* Right: Primary Asset & Actions */}
-          <div className="text-right space-y-3">
+          <div className="text-left sm:text-right space-y-2 sm:space-y-3 w-full sm:w-auto">
             <div>
-              <p className="text-gray-700 text-xs font-medium uppercase tracking-wide mb-1">
+              <p className="text-gray-200 text-2xs sm:text-xs font-medium uppercase tracking-wide mb-1">
                 Primary Asset
               </p>
-              <div className="text-2xl font-bold text-gray-900 drop-shadow">
+              <div className="text-lg sm:text-xl lg:text-2xl font-bold text-white drop-shadow">
                 {showBalance ? `${primaryAsset.balance} ${primaryAsset.symbol}` : "••••••"}
               </div>
-              <p className="text-gray-800 text-sm font-medium">
+              <p className="text-gray-200 text-xs sm:text-sm font-medium">
                 ≈ {showBalance ? formatCurrency(primaryAsset.value) : "••••••"}
               </p>
             </div>
 
             {/* Action Buttons */}
-            <div className="flex gap-2">
+            <div className="flex gap-2 w-full sm:w-auto">
               <Button
                 onClick={onDeposit}
-                className="bg-emerald-600 hover:bg-emerald-700 text-white font-semibold px-6 py-2 rounded-lg shadow-lg transition-all duration-200 hover:scale-105"
+                className="bg-emerald-600 hover:bg-emerald-700 text-white font-semibold px-3 sm:px-6 py-2 rounded-lg shadow-lg transition-all duration-200 hover:scale-105 flex-1 sm:flex-none text-sm sm:text-base"
               >
                 Deposit
               </Button>
               <Button
                 onClick={onWithdraw}
-                className="bg-white hover:bg-gray-50 text-gray-900 border-2 border-gray-300 font-semibold px-6 py-2 rounded-lg shadow-lg transition-all duration-200 hover:scale-105"
+                className="bg-orange-600 hover:bg-orange-700 text-white font-semibold px-3 sm:px-6 py-2 rounded-lg shadow-lg transition-all duration-200 hover:scale-105 flex-1 sm:flex-none text-sm sm:text-base"
               >
                 Withdraw
               </Button>

--- a/src/components/crypto/CryptoWalletBalanceCard.tsx
+++ b/src/components/crypto/CryptoWalletBalanceCard.tsx
@@ -66,21 +66,21 @@ export default function CryptoWalletBalanceCard({
       <CardContent className="relative z-10 p-4 sm:p-6 h-full flex flex-col justify-between">
         {/* Header Row */}
         <div className="flex items-start justify-between">
-          <div className="flex items-center gap-3">
-            <div className="p-2 bg-yellow-400 rounded-xl shadow-lg">
-              <Sparkles className="h-6 w-6 text-gray-900" />
+          <div className="flex items-center gap-2 sm:gap-3">
+            <div className="p-1.5 sm:p-2 bg-yellow-400 rounded-xl shadow-lg">
+              <Sparkles className="h-5 w-5 sm:h-6 sm:w-6 text-gray-900" />
             </div>
             <div>
-              <h2 className="text-xl font-bold text-gray-900 drop-shadow-lg">
+              <h2 className="text-lg sm:text-xl font-bold text-white drop-shadow-lg">
                 Crypto Wallet
               </h2>
-              <p className="text-gray-800 text-sm font-medium drop-shadow">
+              <p className="text-gray-200 text-xs sm:text-sm font-medium drop-shadow">
                 Digital asset portfolio
               </p>
             </div>
           </div>
 
-          <div className="flex items-center gap-2">
+          <div className="flex items-center gap-1 sm:gap-2">
             <Button
               variant="ghost"
               size="sm"

--- a/src/components/crypto/CryptoWalletBalanceCard.tsx
+++ b/src/components/crypto/CryptoWalletBalanceCard.tsx
@@ -85,7 +85,7 @@ export default function CryptoWalletBalanceCard({
               variant="ghost"
               size="sm"
               onClick={() => setShowBalance(!showBalance)}
-              className="text-white hover:bg-white/20 rounded-lg p-1.5 sm:p-2"
+              className="text-gray-900 hover:bg-white/20 rounded-lg p-1.5 sm:p-2"
             >
               {showBalance ? (
                 <EyeOff className="h-3 w-3 sm:h-4 sm:w-4" />

--- a/src/components/crypto/CryptoWalletBalanceCard.tsx
+++ b/src/components/crypto/CryptoWalletBalanceCard.tsx
@@ -102,14 +102,14 @@ export default function CryptoWalletBalanceCard({
         </div>
 
         {/* Main Content Row */}
-        <div className="flex items-center justify-between">
+        <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-4 sm:gap-2">
           {/* Left: Balance */}
-          <div className="space-y-2">
+          <div className="space-y-2 flex-1">
             <div>
-              <p className="text-gray-700 text-xs font-medium uppercase tracking-wide mb-1">
+              <p className="text-gray-200 text-2xs sm:text-xs font-medium uppercase tracking-wide mb-1">
                 Total Portfolio Value
               </p>
-              <div className="text-4xl lg:text-5xl font-bold text-gray-900 drop-shadow-lg">
+              <div className="text-2xl sm:text-3xl lg:text-4xl xl:text-5xl font-bold text-white drop-shadow-lg">
                 {showBalance ? formatCurrency(totalBalance) : "••••••••"}
               </div>
             </div>
@@ -117,24 +117,24 @@ export default function CryptoWalletBalanceCard({
             {/* 24h Change */}
             <div className="flex items-center gap-2">
               <div className={cn(
-                "flex items-center gap-1.5 px-3 py-1.5 rounded-lg font-medium text-sm",
-                isPositive 
-                  ? "bg-emerald-100 text-emerald-800" 
+                "flex items-center gap-1 sm:gap-1.5 px-2 sm:px-3 py-1 sm:py-1.5 rounded-lg font-medium text-2xs sm:text-sm",
+                isPositive
+                  ? "bg-emerald-100 text-emerald-800"
                   : "bg-red-100 text-red-800"
               )}>
                 {isPositive ? (
-                  <TrendingUp className="h-4 w-4" />
+                  <TrendingUp className="h-3 w-3 sm:h-4 sm:w-4" />
                 ) : (
-                  <TrendingDown className="h-4 w-4" />
+                  <TrendingDown className="h-3 w-3 sm:h-4 sm:w-4" />
                 )}
-                <span>
+                <span className="text-2xs sm:text-sm">
                   {showBalance ? formatCurrency(Math.abs(totalBalance24hChange)) : "••••"}
                 </span>
-                <span className="text-xs">
+                <span className="text-2xs sm:text-xs">
                   ({showBalance ? formatPercentage(totalBalance24hPercent) : "••••"})
                 </span>
               </div>
-              <span className="text-gray-700 text-xs font-medium">24h</span>
+              <span className="text-gray-200 text-2xs sm:text-xs font-medium">24h</span>
             </div>
           </div>
 

--- a/src/components/crypto/CryptoWalletBalanceCard.tsx
+++ b/src/components/crypto/CryptoWalletBalanceCard.tsx
@@ -134,7 +134,7 @@ export default function CryptoWalletBalanceCard({
                   ({showBalance ? formatPercentage(totalBalance24hPercent) : "••••"})
                 </span>
               </div>
-              <span className="text-gray-200 text-2xs sm:text-xs font-medium">24h</span>
+              <span className="text-gray-700 text-2xs sm:text-xs font-medium">24h</span>
             </div>
           </div>
 

--- a/src/components/crypto/CryptoWalletBalanceCard.tsx
+++ b/src/components/crypto/CryptoWalletBalanceCard.tsx
@@ -171,17 +171,18 @@ export default function CryptoWalletBalanceCard({
         </div>
 
         {/* Footer Row */}
-        <div className="flex items-center justify-between">
-          <div className="font-mono text-gray-800 text-sm tracking-wider drop-shadow">
+        <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-2 sm:gap-4">
+          <div className="font-mono text-gray-200 text-xs sm:text-sm tracking-wider drop-shadow">
             **** **** **** {String(Math.floor(totalBalance)).slice(-4)}
           </div>
-          
-          <div className="flex items-center gap-4 text-gray-700 text-xs">
-            <div className="flex items-center gap-1.5">
-              <div className="w-2 h-2 bg-emerald-500 rounded-full animate-pulse" />
+
+          <div className="flex items-center gap-2 sm:gap-4 text-gray-200 text-2xs sm:text-xs">
+            <div className="flex items-center gap-1 sm:gap-1.5">
+              <div className="w-1.5 h-1.5 sm:w-2 sm:h-2 bg-emerald-500 rounded-full animate-pulse" />
               <span className="font-medium">Live</span>
             </div>
-            <span>Last updated: {new Date().toLocaleTimeString()}</span>
+            <span className="hidden sm:inline">Last updated: {new Date().toLocaleTimeString()}</span>
+            <span className="sm:hidden">{new Date().toLocaleTimeString()}</span>
           </div>
         </div>
       </CardContent>

--- a/src/components/crypto/CryptoWalletBalanceCard.tsx
+++ b/src/components/crypto/CryptoWalletBalanceCard.tsx
@@ -63,7 +63,7 @@ export default function CryptoWalletBalanceCard({
         backgroundImage: `url("data:image/svg+xml,%3Csvg width='40' height='40' viewBox='0 0 40 40' xmlns='http://www.w3.org/2000/svg'%3E%3Cg fill='white' fill-opacity='0.2'%3E%3Cpath d='M20 20.5V18H40v-2H20v-2.5L23.5 16l-3.5-4-3.5 4L20 13.5V16H0v2h20v2.5L16.5 24l3.5 4 3.5-4L20 20.5z'/%3E%3C/g%3E%3C/svg%3E")`
       }} />
 
-      <CardContent className="relative z-10 p-6 h-full flex flex-col justify-between">
+      <CardContent className="relative z-10 p-4 sm:p-6 h-full flex flex-col justify-between">
         {/* Header Row */}
         <div className="flex items-start justify-between">
           <div className="flex items-center gap-3">

--- a/src/components/crypto/CryptoWalletBalanceCard.tsx
+++ b/src/components/crypto/CryptoWalletBalanceCard.tsx
@@ -172,11 +172,11 @@ export default function CryptoWalletBalanceCard({
 
         {/* Footer Row */}
         <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-2 sm:gap-4">
-          <div className="font-mono text-gray-200 text-xs sm:text-sm tracking-wider drop-shadow">
+          <div className="font-mono text-gray-800 text-xs sm:text-sm tracking-wider drop-shadow">
             **** **** **** {String(Math.floor(totalBalance)).slice(-4)}
           </div>
 
-          <div className="flex items-center gap-2 sm:gap-4 text-gray-200 text-2xs sm:text-xs">
+          <div className="flex items-center gap-2 sm:gap-4 text-gray-700 text-2xs sm:text-xs">
             <div className="flex items-center gap-1 sm:gap-1.5">
               <div className="w-1.5 h-1.5 sm:w-2 sm:h-2 bg-emerald-500 rounded-full animate-pulse" />
               <span className="font-medium">Live</span>

--- a/src/components/crypto/CryptoWalletBalanceCard.tsx
+++ b/src/components/crypto/CryptoWalletBalanceCard.tsx
@@ -51,7 +51,7 @@ export default function CryptoWalletBalanceCard({
         "relative overflow-hidden border-0 shadow-2xl",
         "bg-gradient-to-r from-indigo-600 via-purple-600 to-pink-600",
         "w-full max-w-5xl mx-auto",
-        "aspect-[3/2] min-h-[320px]", // Credit card aspect ratio
+        "min-h-[280px] sm:min-h-[320px] lg:min-h-[360px]", // Responsive height instead of aspect ratio
         className
       )}
     >

--- a/src/components/crypto/CryptoWalletBalanceCard.tsx
+++ b/src/components/crypto/CryptoWalletBalanceCard.tsx
@@ -85,17 +85,17 @@ export default function CryptoWalletBalanceCard({
               variant="ghost"
               size="sm"
               onClick={() => setShowBalance(!showBalance)}
-              className="text-gray-900 hover:bg-white/20 rounded-lg p-2"
+              className="text-white hover:bg-white/20 rounded-lg p-1.5 sm:p-2"
             >
               {showBalance ? (
-                <EyeOff className="h-4 w-4" />
+                <EyeOff className="h-3 w-3 sm:h-4 sm:w-4" />
               ) : (
-                <Eye className="h-4 w-4" />
+                <Eye className="h-3 w-3 sm:h-4 sm:w-4" />
               )}
             </Button>
-            
-            <Badge className="bg-emerald-500 text-white px-3 py-1 text-xs font-semibold shadow-lg">
-              <Shield className="h-3 w-3 mr-1" />
+
+            <Badge className="bg-emerald-500 text-white px-2 sm:px-3 py-1 text-2xs sm:text-xs font-semibold shadow-lg">
+              <Shield className="h-2.5 w-2.5 sm:h-3 sm:w-3 mr-1" />
               Secured
             </Badge>
           </div>


### PR DESCRIPTION
## Purpose
Fix mobile responsiveness issues where content was being cut off on the right side of the layout and improve card color contrast for better visibility on mobile devices.

## Code changes
- **Responsive sizing**: Replaced fixed aspect ratio with responsive min-height breakpoints (`min-h-[280px] sm:min-h-[320px] lg:min-h-[360px]`)
- **Mobile-first spacing**: Added responsive padding (`p-4 sm:p-6`) and gap adjustments throughout
- **Improved text contrast**: Changed text colors from dark gray to white/light gray for better visibility against gradient background
- **Flexible layout**: Updated main content to stack vertically on mobile (`flex-col sm:flex-row`) with proper spacing
- **Responsive typography**: Added responsive text sizing with mobile-optimized scales
- **Button improvements**: Made action buttons full-width on mobile with better color contrast (orange withdraw button)
- **Icon scaling**: Added responsive icon sizes for better mobile touch targets
- **Footer optimization**: Simplified footer layout for mobile with conditional text display

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 151`

🔗 [Edit in Builder.io](https://builder.io/app/projects/6775994fb1a444feb81b2208e6f08d2f/cosmos-works)

👀 [Preview Link](https://6775994fb1a444feb81b2208e6f08d2f-cosmos-works.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>6775994fb1a444feb81b2208e6f08d2f</projectId>-->
<!--<branchName>cosmos-works</branchName>-->